### PR TITLE
Make enter case-insensitive

### DIFF
--- a/src/main/java/com/comandante/creeper/command/MovementCommand.java
+++ b/src/main/java/com/comandante/creeper/command/MovementCommand.java
@@ -89,7 +89,7 @@ public class MovementCommand extends Command {
         if (originalMessageParts.size() > 1) {
             String enterExitName = originalMessageParts.get(1);
             for (RemoteExit remoteExit : currentRoom.getEnterExits()) {
-                if (remoteExit.getExitDetail().equals(enterExitName)) {
+                if (remoteExit.getExitDetail().equalsIgnoreCase(enterExitName)) {
                     return Optional.of(remoteExit);
                 }
             }


### PR DESCRIPTION
Makes the "enter" command's argument case-insensitive, e.g. "enter bank" and "enter Bank" both work.